### PR TITLE
Adjust node requirement to include newer versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "engines": {
     "homebridge": "^1.6.0 || 2.0.0-beta.0",
-    "node": "^16.19.1 || ^18.15.0"
+    "node": "^16.19.1 || >=18.15.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## :recycle: Current situation

Homebridge installs running on Node v20 show this warning upon plugin start. (Issue #74)

`The plugin "homebridge-flume" requires Node.js version of ^16.19.1 || ^18.15.0 which does not satisfy the current Node.js version of v20.11.1. You may need to upgrade your installation of Node.js - see https://homebridge.io/w/JTKEF`

## :bulb: Proposed solution

From what I can tell, the plugin seems to be running fine on Node v20, so I am proposing to allow versions `>=18.15.0`. I have left the `^16.19.1` requirement in place as well in case there was a specific reason for that.

## :gear: Release Notes

* Adjust node requirement to not warn when running on a version greater than v18.15.0
