### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,8 @@ name: Build and Lint
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/mpatfield/homebridge-flume/security/code-scanning/1](https://github.com/mpatfield/homebridge-flume/security/code-scanning/1)

To fix the problem, we should add a `permissions` block to the workflow. Since the workflow only reads repository contents and does not perform any write operations (such as pushing code, creating releases, or modifying issues/pull requests), the minimal required permission is `contents: read`. This block can be added at the workflow root level (above `jobs:`) to apply to all jobs in the workflow. No additional imports or definitions are needed; this is a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
